### PR TITLE
Allow item limits for individual cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,10 @@ The Legumeinfo Jekyll theme supports the following entries:
 * `description: String (the description used in the site meta)`
 * `baseurl: String (the subpath of your site, e.g. /blog)`
 * `url: String (the base hostname & protocol for your site, e.g. http://example.com)`
-* `card\_item\_limit (optional): Integer (maximum number of items to display in each card)`
+* `card\_item\_limit (optional): Integer (maximum number of items to display in each card for which no individual limit is specified)`
+* `news\_card\_item\_limit (optional): Integer (maximum number of items to display in the News card)`
+* `events\_card\_item\_limit (optional): Integer (maximum number of items to display in the Events card)`
+* `twitter\_card\_item\_limit (optional): Integer (maximum number of items to display in the Twitter card)`
 * `twitter\_username (optional): String (the site's Twitter handle for social media links)`
 * `github\_username (optional): String (the site's GitHub handle for social media links)`
 * `newsletter (optional): String (the URL to where users can sign up for your site's newsletter)`

--- a/_includes/events-card.html
+++ b/_includes/events-card.html
@@ -36,7 +36,7 @@ Populate the widget using JavaScript so the site doesn't have to be rebuilt when
       },
     {% endfor %}
     ];
-  /* only keep soonest {{ site.card_item_limit }} events that are currently happening or upcoming */
+  /* only keep soonest eventsLimit events that are currently happening or upcoming */
   const eventsLimit = {% if site.events_card_item_limit %}
     {{ site.events_card_item_limit }}
   {% else %}

--- a/_includes/events-card.html
+++ b/_includes/events-card.html
@@ -37,10 +37,15 @@ Populate the widget using JavaScript so the site doesn't have to be rebuilt when
     {% endfor %}
     ];
   /* only keep soonest {{ site.card_item_limit }} events that are currently happening or upcoming */
+  const eventsLimit = {% if site.events_card_item_limit %}
+    {{ site.events_card_item_limit }}
+  {% else %}
+    {{ site.card_item_limit }}
+  {% endif %};
   const currentUnixDate = Math.floor(Date.now() / 1000);
   const upcomingEvents = events
     .filter((event) => event.unixDate >= currentUnixDate || event.unixEndDate >= currentUnixDate)
-    .slice(0, {{ site.card_item_limit }});
+    .slice(0, eventsLimit);
   /* generate HTML for each event */
   const listItems = upcomingEvents
     .map((event) => {

--- a/_includes/news-card.html
+++ b/_includes/news-card.html
@@ -8,7 +8,11 @@
   </div>
   <div class="uk-card-body">
     <ul class="uk-list uk-list-disc">
-      {% for post in site.categories.news limit:site.card_item_limit %}
+      {% assign newsLimit = site.card_item_limit %}
+      {% if site.news_card_item_limit %}
+        {% assign newsLimit = site.news_card_item_limit %}
+      {% endif %}
+      {% for post in site.categories.news limit:newsLimit %}
       <li><a href="{{ post.url }}"><b>{{ post.title }}</b></a></li>
       {% endfor %}
     </ul>

--- a/_includes/twitter-card.html
+++ b/_includes/twitter-card.html
@@ -15,7 +15,11 @@
   <!-- code from Twitter -->
   <a class="twitter-timeline uk-padding-small"
     href="https://twitter.com/{{ site.twitter_username }}"
-    data-tweet-limit={{ site.card_item_limit }}
+    data-tweet-limit={% if site.twitter_card_item_limit %}
+      {{ site.twitter_card_item_limit }}
+    {% else %}
+      {{ site.card_item_limit }}
+    {% endif %}
     data-chrome="noheader, nofooter, noborders"
     dnt=true
   >Tweets by {{ site.twitter_username }}</a>


### PR DESCRIPTION
Allow separate item limits in the News, Events, and Twitter cards. If not specified, they use existing card_item_limit.