### PR TITLE
Full width layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ The Legumeinfo Jekyll theme provides the following layouts:
 * `page`
 * `post`
 * `reading-width`
+* `full-width`
 
 It is recommend that each page uses the `default` layout unless the page corresponds to a previously described page that has a specific layout.
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@ layout: base
   {% include left-menu.html %}
 {% endif %}
 <!-- NOTE: putting content between the tools and tm-main blocks will break CSS selectors -->
-<div class="tm-main uk-section uk-section-default uk-flex">
+<div class="tm-main uk-section uk-section-default">
   <div class="uk-container uk-width-1-1">
     {{ content }}
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@ layout: base
   {% include left-menu.html %}
 {% endif %}
 <!-- NOTE: putting content between the tools and tm-main blocks will break CSS selectors -->
-<div class="tm-main uk-section uk-section-default">
+<div class="tm-main uk-section uk-section-default uk-flex">
   <div class="uk-container uk-width-1-1">
     {{ content }}
   </div>

--- a/_layouts/full-width.html
+++ b/_layouts/full-width.html
@@ -1,7 +1,7 @@
 ---
 layout: base
 ---
-<div class="tm-main uk-section uk-section-default uk-flex">
+<div class="tm-main uk-section uk-section-default">
   <div class="uk-container uk-container-expand">
     {{ content }}
   </div>

--- a/_layouts/full-width.html
+++ b/_layouts/full-width.html
@@ -1,0 +1,8 @@
+---
+layout: base
+---
+<div class="tm-main uk-section uk-section-default uk-flex">
+  <div class="uk-container uk-container-expand">
+    {{ content }}
+  </div>
+</div>


### PR DESCRIPTION
This adds a `full-width` layout to be used on wide pages like gene search results.

It can be tested against the **use-theme** branch of jekyll-legumeinfo, which uses it in the gene search.