### PR TITLE
Graphql scripts2

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ The Legumeinfo Jekyll theme supports the following entries:
     * `link_hover_color`: String (what color HTML links should be when hovered)
     * `primary_background`: String (what the background color of the main navbar should be)
     * `invert_navbar_text`: Boolean (whether or not to invert the navbar text color)
-* `web_components_version` (default=`1.0.0`): String (the version of the LIS Web Components JavaScript library to use; see the [LIS Web Components](#lis-web-components) section for details)
+* `web_components_version` (default=`1.0.0`): String (the version of the LIS Web Components JavaScript library to use; see the [Web Components](#web-components) section for details)
+* `graphql_uri` (default=`https://graphql.lis.ncgr.org/`): String (the URI of the GraphQL Server the theme should load data from; see the [GraphQL Support](#graphql-support) section for details)
 
 As described above, you'll need to add the Legumeinfo Jekyll theme in your `_config.yml`.
 And you'll need to add `future: true` if you want to use the themes events features.
@@ -321,7 +322,7 @@ defaults:
       tools_menu: true
 ```
 
-### LIS Web Components
+### Web Components
 
 The theme uses the [LIS Web Components](https://www.npmjs.com/package/@legumeinfo/web-components) JavaScript library to support dynamic functionality, such as gene search.
 Since not every page needs Web Components, you must "opt-in" to including the LIS Web Components JavaScript on pages you want to use components in.
@@ -332,10 +333,26 @@ For example:
 web_components: true
 ---
 
-<lis-gene-search-element></lis-gene-search-element>
+<lis-gene-search-element id="gene-search"></lis-gene-search-element>
+
+<script type="module">
+  import {getOrganismsFormData, geneSearch} from "lis-graphql";
+  const geneSearchElement = document.getElementById('gene-search');
+  geneSearchElement.formDataFunction = getOrganismsFormData;
+  geneSearchElement.searchFunction = geneSearch;
+</script>
 ```
 The theme specifies which version of the LIS Web Components JavaScript library to use.
 However, this can be overridden using the `web_components_version` variable in the [`_config.yml` file](#_configyml).
+
+### GraphQL Support
+
+LIS uses a [GraphQL Server](https://github.com/legumeinfo/graphql-server) to provide a consistent, interconnected API for accessing its data and services.
+For convenience, the theme provides JavaScript for querying a GraphQL Server, including functions that fetch and format data for specific Web Components.
+These scripts are available via the `lis-graphql` JavaScript module.
+This module can be loaded on any page by simply importing one or more features from the module, as demonstrated in [Web Components](#web-components).
+The theme loads data from the LIS GraphQL Server by default.
+However, this can be overridden using the `graphql_uri` variable in the [`_config.yml` file](#_configyml).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -336,10 +336,10 @@ web_components: true
 <lis-gene-search-element id="gene-search"></lis-gene-search-element>
 
 <script type="module">
-  import {getOrganismsFormData, geneSearch} from "lis-graphql";
+  import {getOrganismsFormDataFunction, geneSearchFunction} from "lis-graphql";
   const geneSearchElement = document.getElementById('gene-search');
-  geneSearchElement.formDataFunction = getOrganismsFormData;
-  geneSearchElement.searchFunction = geneSearch;
+  geneSearchElement.formDataFunction = getOrganismsFormDataFunction;
+  geneSearchElement.searchFunction = geneSearchFunction;
 </script>
 ```
 The theme specifies which version of the LIS Web Components JavaScript library to use.

--- a/_config.yml
+++ b/_config.yml
@@ -35,3 +35,6 @@ future: true
 
 # the default number of items shown in card widgets
 card_item_limit: 3
+
+# the GraphQL Server URI; LIS by default
+graphql_uri: https://graphql.lis.ncgr.org/

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,6 +27,15 @@
 
   {% include global-scripts.html %}
 
+  <!-- opt-in code for integrating GraphQL with LIS Web Components -->
+  <script type="importmap">
+    {
+      "imports": {
+        "lis-graphql": "{{ "assets/js/graphql/index.js" | relative_url }}"
+      }
+    }
+  </script>
+
   {% if page.web_components and site.web_components_version %}
   <!-- LIS Web Components -->
   <script type="module" src="https://cdn.jsdelivr.net/npm/@legumeinfo/web-components@{{ site.web_components_version }}/dist/web-components.min.js"></script>

--- a/assets/js/graphql/get-genes.js
+++ b/assets/js/graphql/get-genes.js
@@ -1,0 +1,82 @@
+import { query } from './query.js';
+
+
+export const getGenesQuery = `
+  query GenesQuery($identifier: String, $name: String, $description: String, $genus: String, $species: String, $strain: String, $family: String, $page: Int, $pageSize: Int) {
+    genes(genus: $genus, species: $species, strain: $strain, identifier: $identifier, name: $name, description: $description, geneFamilyIdentifier: $family, page: $page, pageSize: $pageSize) {
+      results {
+        name
+        identifier
+        description
+        organism { genus species }
+        strain { identifier }
+        geneFamilyAssignments { geneFamily { identifier } }
+        locations { chromosome { identifier } supercontig { identifier } start end strand }
+      }
+      pageInfo {
+        hasNextPage
+        numResults
+        pageSize
+        pageCount
+      }
+    }
+  }
+  `;
+      
+
+export function getGenes(queryData={}, pageData={}, options={}) {
+  const {genus, species, strain, identifier, description, family} = queryData;
+  const {page, pageSize} = pageData;
+  const variables = {
+    genus,
+    species,
+    strain,
+    identifier,
+    description,
+    family,
+    page,
+    pageSize,
+  };
+  const {abortSignal} = options;
+  return query(getGenesQuery, variables, abortSignal);
+}
+
+
+export function genesDataToSearchResults(data) {
+  // extract the page info
+  const {hasNextPage: hasNext, numResults, pageSize, pageCount: numPages}
+    = data.genes.pageInfo;
+  // flatten results
+  const results =
+    data.genes.results.map(({organism: {genus, species}, strain, ...gene}) => {
+      const geneFamilyAssignments =
+        gene.geneFamilyAssignments
+          .map(({geneFamily: {identifier}}) => identifier);
+      const locations =
+        gene.locations.map(({chromosome, supercontig, start, end, strand}) => {
+          const interval = `${start}-${end} (${strand})`;
+          if (chromosome?.identifier) {
+            return `${chromosome?.identifier}:${interval} (chromosome)`;
+          } else if (supercontig?.identifier) {
+            return `${supercontig?.identifier}:${interval} (supercontig)`;
+          }
+          return `unknown:${interval}`;
+        });
+      return {
+        genus,
+        species,
+        strain: strain.identifier,
+        ...gene,
+        geneFamilyAssignments,
+        locations,
+      };
+    });
+  // return the expected paginated results object
+  return {hasNext, numResults, pageSize, numPages, results};
+}
+      
+
+export function geneSearch(queryData, page, options={}) {
+  return getGenes(queryData, {page, pageSize: 10}, options)
+    .then(({data}) => genesDataToSearchResults(data));
+}

--- a/assets/js/graphql/get-linkouts.js
+++ b/assets/js/graphql/get-linkouts.js
@@ -1,0 +1,76 @@
+import { query } from './query.js';
+
+
+export const getGeneLinkoutsQuery = `
+  query GeneLinkoutsQuery($identifier: ID!) {
+    geneLinkouts(identifier: $identifier) {
+      results {
+        href
+        text
+      }
+    }
+  }
+  `;
+
+
+export function getGeneLinkouts(queryData={}, options={}) { 
+  const {identifier} = queryData;
+  const variables = {identifier}; 
+  const {abortSignal} = options;
+  return query(getGeneLinkoutsQuery, variables, abortSignal);
+}
+
+
+export function geneLinkoutsToLinkoutResults(data) {
+  const results = data.geneLinkouts.results;
+  return {results};
+}
+
+
+export function geneLinkoutsFunction(linkoutData, options) {
+    return getGeneLinkouts(linkoutData, options)
+      .then(({data}) => geneLinkoutsToLinkoutResults(data)); 
+}
+
+
+export const getLocationLinkoutsQuery = `
+  query LocationLinkoutsQuery($identifier: ID!, $start: Int!, $end: Int!) {
+    locationLinkouts(identifier: $identifier, start: $start, end: $end) {
+      results {
+        href
+        text
+      }
+    }
+  }
+  `;
+
+
+export function getLocationLinkouts(queryData={}, options={}) {
+  const {identifier, start, end} = queryData;
+  const variables = {identifier, start: parseInt(start), end: parseInt(end)}; 
+  const {abortSignal} = options;
+  return query(getLocationLinkoutsQuery, variables, abortSignal);
+}
+
+
+export function locationLinkoutsToLinkoutResults(data) {
+  const results = data.locationLinkouts.results;
+  return {results};
+}
+
+
+export function locationLinkoutsFunction(linkoutData, options) {
+    return getLocationLinkouts(linkoutData, options)
+      .then(({data}) => locationLinkoutsToLinkoutResults(data)); 
+}
+
+
+export function allLinkoutsFunction({type, linkoutData}, options) {
+  switch (type) {
+    case 'gene':
+      return geneLinkoutsFunction(linkoutData, options);
+    case 'location':
+      return locationLinkoutsFunction(linkoutData, options);
+  }
+  return Promise.reject();
+}

--- a/assets/js/graphql/get-linkouts.js
+++ b/assets/js/graphql/get-linkouts.js
@@ -1,6 +1,7 @@
 import { query } from './query.js';
 
 
+/** The GraphQL query used to get linkouts for genes. */
 export const getGeneLinkoutsQuery = `
   query GeneLinkoutsQuery($identifier: ID!) {
     geneLinkouts(identifier: $identifier) {
@@ -10,29 +11,51 @@ export const getGeneLinkoutsQuery = `
       }
     }
   }
-  `;
+`;
 
 
-export function getGeneLinkouts(queryData={}, options={}) { 
+/**
+ * Gets linkouts for genes from GraphQL.
+ * @param {object} queryData - An object containing zero or more variables for the GraphQL query.
+ * @param {object} options - An object containing optional parameters for the HTTP request,
+ * namely, an optional `AbortSignal` instance that can be used to cancel the request mid-flight.
+ * @returns {Promise} A `Promise` that resolves to the result of the GraphQL query.
+ */
+export function getGeneLinkouts(queryData={}, options={}) {
   const {identifier} = queryData;
-  const variables = {identifier}; 
+  const variables = {identifier};
   const {abortSignal} = options;
   return query(getGeneLinkoutsQuery, variables, abortSignal);
 }
 
 
+/**
+ * Converts GraphQL `GeneLinkoutsResults` into the `LinkoutResults` used by the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component.
+ * @param {object} data - An object containing the data portional of the GraphQL query HTTP response.
+ * @returns {object} A `LinkoutResults` object.
+ */
 export function geneLinkoutsToLinkoutResults(data) {
   const results = data.geneLinkouts.results;
   return {results};
 }
 
 
+/**
+ * The gene linkouts function to use for the `linkoutFunction` property of the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component.
+ * @param {object} linkoutData - An object containing the data needed to get linkouts.
+ * @param {object} options - An object containing optional parameters to pass to the `getGeneLinkouts` function.
+ * @returns {Promise} A `Promise` that resolves to the `LinkoutResults` used by the
+ * `LisLinkoutElement` (`<lis-linkout-element>`) Web Component.
+ */
 export function geneLinkoutsFunction(linkoutData, options) {
-    return getGeneLinkouts(linkoutData, options)
-      .then(({data}) => geneLinkoutsToLinkoutResults(data)); 
+  return getGeneLinkouts(linkoutData, options)
+    .then(({data}) => geneLinkoutsToLinkoutResults(data));
 }
 
 
+/** The GraphQL query used to get linkouts for locations. */
 export const getLocationLinkoutsQuery = `
   query LocationLinkoutsQuery($identifier: ID!, $start: Int!, $end: Int!) {
     locationLinkouts(identifier: $identifier, start: $start, end: $end) {
@@ -42,29 +65,58 @@ export const getLocationLinkoutsQuery = `
       }
     }
   }
-  `;
+`;
 
 
+/**
+ * Gets linkouts for locations from GraphQL.
+ * @param {object} queryData - An object containing zero or more variables for the GraphQL query.
+ * @param {object} options - An object containing optional parameters for the HTTP request,
+ * namely, an optional `AbortSignal` instance that can be used to cancel the request mid-flight.
+ * @returns {Promise} A `Promise` that resolves to the result of the GraphQL query.
+ */
 export function getLocationLinkouts(queryData={}, options={}) {
   const {identifier, start, end} = queryData;
-  const variables = {identifier, start: parseInt(start), end: parseInt(end)}; 
+  const variables = {identifier, start: parseInt(start), end: parseInt(end)};
   const {abortSignal} = options;
   return query(getLocationLinkoutsQuery, variables, abortSignal);
 }
 
 
+/**
+ * Converts GraphQL `LocationLinkoutsResults` into the `LinkoutResults` used by the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component.
+ * @param {object} data - An object containing the data portional of the GraphQL query HTTP response.
+ * @returns {object} A `LinkoutResults` object.
+ */
 export function locationLinkoutsToLinkoutResults(data) {
   const results = data.locationLinkouts.results;
   return {results};
 }
 
 
+/**
+ * The location linkouts function to use for the `linkoutFunction` property of the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component.
+ * @param {object} linkoutData - An object containing the data needed to get linkouts.
+ * @param {object} options - An object containing optional parameters to pass to the `getLocationLinkouts` function.
+ * @returns {Promise} A `Promise` that resolves to the `LinkoutResults` used by the
+ * `LisLinkoutElement` (`<lis-linkout-element>`) Web Component.
+ */
 export function locationLinkoutsFunction(linkoutData, options) {
-    return getLocationLinkouts(linkoutData, options)
-      .then(({data}) => locationLinkoutsToLinkoutResults(data)); 
+  return getLocationLinkouts(linkoutData, options)
+    .then(({data}) => locationLinkoutsToLinkoutResults(data));
 }
 
 
+/**
+ * A linkouts function to use for the `linkoutFunction` property of the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component that supports all linkout types.
+ * @param {object} {type, linkoutData} - An object containing the linkout type and the data needed to get linkouts for that type.
+ * @param {object} options - An object containing optional parameters to pass to the `getGeneLinkouts` function.
+ * @returns {Promise} A `Promise` that resolves to the `LinkoutResults` used by the
+ * `LisLinkoutElement` (`<lis-linkout-element>`) Web Component.
+ */
 export function allLinkoutsFunction({type, linkoutData}, options) {
   switch (type) {
     case 'gene':

--- a/assets/js/graphql/get-organisms.js
+++ b/assets/js/graphql/get-organisms.js
@@ -62,7 +62,7 @@ export function organismsDataToFormData(data) {
 }
 
 
-export function getOrganismsFormData(queryData={}, pageData={}, options={}) {
+export function getOrganismsFormDataFunction(queryData={}, pageData={}, options={}) {
   return getOrganisms(queryData, pageData, options)
     .then(({data}) => organismsDataToFormData(data));
 }

--- a/assets/js/graphql/get-organisms.js
+++ b/assets/js/graphql/get-organisms.js
@@ -1,6 +1,7 @@
 import { query } from './query.js';
 
 
+/** The GraphQL query used to get organisms. */
 export const getOrganismsQuery = `
   query OganismsQuery($taxonId: Int, $abbreviation: String, $name: String, $genus: String, $species: String, $page: Int, $pageSize: Int) {
   organisms(taxonId: $taxonId, abbreviation: $abbreviation, name: $name, genus: $genus, species: $species, page: $page, pageSize: $pageSize) {
@@ -16,6 +17,14 @@ export const getOrganismsQuery = `
   `;
 
 
+/**
+ * Gets organisms from GraphQL.
+ * @param {object} queryData - An object containing zero or more variables for the GraphQL query.
+ * @param {object} pageData - An object containing pagination data for the GraphQL query, if any.
+ * @param {object} options - An object containing optional parameters for the HTTP request,
+ * namely, an optional `AbortSignal` instance that can be used to cancel the request mid-flight.
+ * @returns {Promise} A `Promise` that resolves to the result of the GraphQL query.
+ */
 export function getOrganisms(queryData={}, pageData={}, options={}) {
   const {taxonId, abbreviation, name, genus, species} = queryData;
   const {page, pageSize} = pageData;
@@ -33,6 +42,12 @@ export function getOrganisms(queryData={}, pageData={}, options={}) {
 }
 
 
+/**
+ * Converts GraphQL `OrganismsResults` into the `*SearchFormData` used by the
+ * `LisGeneSearchElement` (`<lis-gene-search-element>`) Web Component.
+ * @param {object} data - An object containing the data portional of the GraphQL query HTTP response.
+ * @returns {object} A `*SearchFormData` object.
+ */
 export function organismsDataToFormData(data) {
   // bin the strains by genus then species
   const binnedFormData = {};
@@ -62,6 +77,15 @@ export function organismsDataToFormData(data) {
 }
 
 
+/**
+ * The organisms form data function to use for the `formDataFunction` property of the `LisGeneSearchElement`
+ * (`<lis-gene-search-element>`) Web Component.
+ * @param {object} queryData - An object containing the data needed to get organisms.
+ * @param {object} pageData - An object containing pagination data for the GraphQL query, if any.
+ * @param {object} options - An object containing optional parameters to pass to the `getOrganisms` function.
+ * @returns {Promise} A `Promise` that resolves to the `*SearchFormData` used by the `LisGeneSearchElement`
+ * (`<lis-gene-search-element>`) Web Component.
+ */
 export function getOrganismsFormDataFunction(queryData={}, pageData={}, options={}) {
   return getOrganisms(queryData, pageData, options)
     .then(({data}) => organismsDataToFormData(data));

--- a/assets/js/graphql/get-organisms.js
+++ b/assets/js/graphql/get-organisms.js
@@ -1,0 +1,68 @@
+import { query } from './query.js';
+
+
+export const getOrganismsQuery = `
+  query OganismsQuery($taxonId: Int, $abbreviation: String, $name: String, $genus: String, $species: String, $page: Int, $pageSize: Int) {
+  organisms(taxonId: $taxonId, abbreviation: $abbreviation, name: $name, genus: $genus, species: $species, page: $page, pageSize: $pageSize) {
+      results {
+        genus
+        species
+        strains {
+          identifier
+        }
+      }
+    }
+  }
+  `;
+
+
+export function getOrganisms(queryData={}, pageData={}, options={}) {
+  const {taxonId, abbreviation, name, genus, species} = queryData;
+  const {page, pageSize} = pageData;
+  const variables = {
+    taxonId,
+    abbreviation,
+    name,
+    genus,
+    species,
+    page,
+    pageSize,
+  };
+  const {abortSignal} = options;
+  return query(getOrganismsQuery, variables, abortSignal);
+}
+
+
+export function organismsDataToFormData(data) {
+  // bin the strains by genus then species
+  const binnedFormData = {};
+  data.organisms.results.forEach(({genus, species, strains}) => {
+    if (!(genus in binnedFormData)) {
+      binnedFormData[genus] = {}
+    }
+    if (!(species in binnedFormData[genus])) {
+      binnedFormData[genus][species] = [];
+    }
+    binnedFormData[genus][species].push(...strains);
+  });
+  // collapse the bins into arrays of objects
+  const genuses =
+    Object.entries(binnedFormData).map(([genus, binnedSpecies]) => {
+      const species =
+        Object.entries(binnedSpecies).map(([species, strainObjects]) => {
+          const strains = strainObjects.map(({identifier}) => {
+            return {strain: identifier};
+          });
+          return {species, strains};
+        });
+      return {genus, species};
+    });
+  // return the expected form data object
+  return {genuses};
+}
+
+
+export function getOrganismsFormData(queryData={}, pageData={}, options={}) {
+  return getOrganisms(queryData, pageData, options)
+    .then(({data}) => organismsDataToFormData(data));
+}

--- a/assets/js/graphql/index.js
+++ b/assets/js/graphql/index.js
@@ -1,0 +1,3 @@
+export * from './get-genes.js';
+export * from './get-organisms.js';
+export * from './query.js';

--- a/assets/js/graphql/index.js
+++ b/assets/js/graphql/index.js
@@ -1,3 +1,5 @@
 export * from './get-genes.js';
+export * from './get-linkouts.js';
 export * from './get-organisms.js';
+export * from './modal.js';
 export * from './query.js';

--- a/assets/js/graphql/modal.js
+++ b/assets/js/graphql/modal.js
@@ -1,3 +1,10 @@
+/**
+ * Creates a link with the given `data` attributes that opens a modal with the given `modalId`.
+ * @param {string} modalId - The HTML `id` of the target modal element.
+ * @param {string} text - The text of the link.
+ * @param {object} data - The data attributes to add to the link.
+ * @returns {string} The created link.
+ */
 export function modalLink(modalId, text, data={}) {
   const dataAttrs =
     Object.entries(data)
@@ -7,6 +14,11 @@ export function modalLink(modalId, text, data={}) {
 }
 
 
+/**
+ * Extracts the `data` embedded by `modalLink` from the given modal `event`.
+ * @param {Event} event - The modal event to extract data from.
+ * @returns {object} The data extracted from the event.
+ */
 export function modalEventToLinkData(event) {
   const [{$el: link}, ...uikitComponents] = event.detail;
   return link.dataset;

--- a/assets/js/graphql/modal.js
+++ b/assets/js/graphql/modal.js
@@ -1,0 +1,13 @@
+export function modalLink(modalId, text, data={}) {
+  const dataAttrs =
+    Object.entries(data)
+      .map(([key, value]) => `data-${key}="${value}"`)
+      .join(' ');
+  return `<a href="#${modalId}" ${dataAttrs} uk-toggle>${text}</a>`;
+}
+
+
+export function modalEventToLinkData(event) {
+  const [{$el: link}, ...uikitComponents] = event.detail;
+  return link.dataset;
+}

--- a/assets/js/graphql/query.js
+++ b/assets/js/graphql/query.js
@@ -1,0 +1,32 @@
+---
+# This YAML front matter ensures Jekyll will pass the site variables in.
+---
+
+// hard-code the URI for now; we can update the code to allow URI override
+// at run-time if need be.
+const uri = "{{ site.graphql_uri }}";
+
+
+// A function that gets data from a GraphQL server via a POST request.
+// Adapted from https://graphql.org/graphql-js/graphql-clients/
+export function query(query, variables={}, abortSignal=undefined) {
+    return fetch(uri, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        },
+        body: JSON.stringify({
+            query,
+            variables,
+        }),
+        signal: abortSignal,
+    })
+    .then(r => r.json())
+    .then((response) => {
+      if (response.errors) {
+        response.errors.forEach(console.error);
+      }
+      return response;
+    });
+}

--- a/assets/js/graphql/query.js
+++ b/assets/js/graphql/query.js
@@ -2,13 +2,17 @@
 # This YAML front matter ensures Jekyll will pass the site variables in.
 ---
 
-// hard-code the URI for now; we can update the code to allow URI override
-// at run-time if need be.
+/** The URI of the GraphQL server to query. */
 const uri = "{{ site.graphql_uri }}";
 
 
-// A function that gets data from a GraphQL server via a POST request.
-// Adapted from https://graphql.org/graphql-js/graphql-clients/
+/**
+ * Gets data from a GraphQL server via a POST request.
+ * Adapted from https://graphql.org/graphql-js/graphql-clients/
+ * @param {string} query - The GraphQL query.
+ * @param {object} variables - The variables for the GraphQL query.
+ * @returns {Promise<Response>} A `Promise` that resolves to a `Response` object.
+ */
 export function query(query, variables={}, abortSignal=undefined) {
     return fetch(uri, {
         method: 'POST',


### PR DESCRIPTION
Adds GraphQL scripts from the Web Components repo. See issue #39 for details.

Once merged, complete examples of how to use the scripts will be added to the starter site; see issue [#5](https://github.com/legumeinfo/jekyll-starter-legumeinfo/issues/5). For now, here's an example of using the gene search component with modal and linkout component integration:
```liquid
---
layout: full-width
title: Components
web_components: true
---


<lis-gene-search-element id="gene-search"></lis-gene-search-element>
<lis-modal-element modalId="modal">
  <lis-linkout-element id="linkouts"></lis-linkout-element>
</lis-modal-element>


<script type="module">

  import {
    // genes
    getOrganismsFormDataFunction,
    geneSearchFunctionFactory,
    allModalLinksFactory,
    // linkouts
    allLinkoutsFunction,
    // modal
    modalEventToLinkData
  } from "lis-graphql";

  const geneSearchElement = document.getElementById('gene-search');
  geneSearchElement.formDataFunction = getOrganismsFormDataFunction;
  const seachDataProcessors = allModalLinksFactory('modal');
  geneSearchElement.searchFunction =
    geneSearchFunctionFactory(...seachDataProcessors);

  const linkoutElement = document.getElementById('linkouts');
  linkoutElement.linkoutFunction = allLinkoutsFunction;

  // wait for the modal slot to load before adding an event listener
  window.onload = (event) => {
    const modal = document.getElementById('modal');
    modal.addEventListener('toggle', (event) => {
      const {type, ...linkoutData} = modalEventToLinkData(event);
      linkoutElement.getLinkouts({type, linkoutData});
    });
  };

</script>
```