### PR TITLE
Replaces the file_exists tag with a manual check

### DIFF
--- a/_layouts/taxon.html
+++ b/_layouts/taxon.html
@@ -40,7 +40,8 @@ taxa_menu: true
 <h3 id="{{ item["species"] }}"><i>{{ item["genus"] }} {{ item["species"] }}</i>: {{ item["commonName"] }}</h3>
 {% endif %}
 
-{% assign species_photo = site.static_files | where: "path", "assets/img/species_images/{{ item["abbrev"] }}.jpg" | first %}
+{% capture species_photo_path %}assets/img/species_images/{{ item["abbrev"] }}.jpg{% endcapture %}
+{% assign species_photo = site.static_files | where: "path", species_photo_path | first %}
 {% if species_photo %}
 <div class="species-image">
   <img src="/assets/img/species_images/{{ item["abbrev"] }}.jpg" alt="Image: {{ item["commonName"] }}"/>

--- a/_layouts/taxon.html
+++ b/_layouts/taxon.html
@@ -40,8 +40,8 @@ taxa_menu: true
 <h3 id="{{ item["species"] }}"><i>{{ item["genus"] }} {{ item["species"] }}</i>: {{ item["commonName"] }}</h3>
 {% endif %}
 
-{% capture species_photo %}{% file_exists assets/img/species_images/{{ item["abbrev"] }}.jpg %}{% endcapture %}
-{% if species_photo == "true" %}
+{% assign species_photo = site.static_files | where: "path", "assets/img/species_images/{{ item["abbrev"] }}.jpg" | first %}
+{% if species_photo %}
 <div class="species-image">
   <img src="/assets/img/species_images/{{ item["abbrev"] }}.jpg" alt="Image: {{ item["commonName"] }}"/>
   {% for attribItem in site.data.species_image_attribution %}


### PR DESCRIPTION
Currently the page gen functionality provided by the theme doesn't work unless the site using the theme installs the file_exists plugin (issue #44). As the commit comment explains, "[file_exists] isn't published on rubygems.org making it impossible to specify in the gemspec file, and plugins can't be intsalled locally in a theme." So instead of requiring sites that use the theme to install the plugin, I just replaced the one time it's used with a manual check, which is itself pretty straightforward.

The solution is from this blog post: https://devopsx.com/jekyll-check-if-file-exists/