### PR TITLE
Set alerts via _data/alerts.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ root/
 │   ├── img/
 │   └── js/
 ├── _data/
+│   ├── alerts.yml
 │   ├── taxa_main.yml
 │   ├── taxa_special.yml
 │   └── tools.yml
 ├── _includes
-│   ├── alerts.html
 │   ├── global-scripts.html
 │   ├── global-stylesheets.html
 │   ├── navbar-menu.html
@@ -120,11 +120,20 @@ To include custom JavaScript in your site, put your scripts in the `assets/js/` 
 The `_data/` directory is used by Jekyll to load static data that is not accommodated by its blog model.
 The Legumeinfo Jekyll theme expects two files to be in this directory: `species.yml` and `tools.yml`.
 
+**`alerts.yml`** This file contains a list of alerts to be shown on top of the navbar in every page on the site. If the list is not empty, a bell icon will be added to the far right side of the navbar which can be used to toggle the element containing the alerts. Each alert in the list should adhere to the following schema pattern:
+
+```yml
+---
+-
+  type: "primary"|"success"|"warning"|"danger"
+  message: "<b>Welcome to the legumeinfo Jekyll starter site!</b> The site's code can be found on <a href='https://github.com/legumeinfo/jekyll-starter-legumeinfo' target='_blank'>GitHub</a>. Click the bell (<span uk-icon='bell'></span>) in the navigation bar to toggle this alert."
+```
+
 **`taxa_main.yml` and `taxa_special.yml`** These files contains a list of taxa (genera) that the data portal provides 
 omics data for. The taxa_main file contains major crop and models; taxa_special contains everything else.
 The list should adhere to the following schema pattern:
 
-```
+```yml
 ---
 - genus: Arachis
   description: "(peanut: domesticated and wild)"
@@ -166,8 +175,6 @@ The tools within the list will be grouped by category.
 ### `_include/`
 
 The `_include/` directory is used by Jekyll to place globally-included content onto the site. These files will replace the files of the same name in the theme.
-
-**`alerts.html`** contains alerts that will be displayed in the navbar at the very top of the page. This file may be empty. If the file is not empty, a bell icon will be added to the far right side of the navbar which can be used to toggle the element containing the alerts.
 
 **`navbar-menu.html`** contains the navigation bar menu seen on every page. It is recommended that this menu is given a [responsive width](https://getuikit.com/docs/width#responsive-width) so it can be replaced with a more compact menu on smaller screens. If using an off-screen menu (described below), it is recommend that the toggle component is placed here (see the [`_includes/navbar-menu.html`](https://github.com/legumeinfo/jekyll-theme-legumeinfo/blob/main/_includes/navbar-menu.html) for an example).
 

--- a/_includes/alerts.html
+++ b/_includes/alerts.html
@@ -1,3 +1,7 @@
-<div class="uk-alert-primary uk-margin-remove" uk-alert>
-  <p><b>Welcome to the legumeinfo Jekyll theme!</b> The theme can be found on <a href="https://github.com/legumeinfo/jekyll-theme-legumeinfo" target="_blank">GitHub</a>. Click the bell (<span uk-icon="bell"></span>) in the navigation bar to toggle this alert.</p>
+{% if site.data.alerts %}
+{% for alert in site.data.alerts %}
+<div class="uk-alert-{{ alert.type }}" uk-alert>
+  <p>{{ alert.message }}</p>
 </div>
+{% endfor %}
+{% endif %}

--- a/assets/css/uikit-theme.scss
+++ b/assets/css/uikit-theme.scss
@@ -275,6 +275,11 @@ html {
     background: $global-primary-background;
 }
 
+.tm-navbar-container .uk-alert {
+    margin: 0;
+    border-bottom: 1px solid;
+}
+
 .tm-navbar-container .uk-navbar-nav > li > a,
 .tm-navbar-container .uk-navbar-item:not(.uk-logo),
 .tm-navbar-container .uk-navbar-toggle {


### PR DESCRIPTION
This addresses issue #19. Note that it won't break existing sites that set alerts by defining their own `_includes/alerts.html` file. However, I recommend transitioning to the approach in this PR as it handles styling for you and it will be the officially supported approach moving forward.

@svengato I'm requesting you as a reviewer because peanutbase is currently using the `_includes/alerts.html` approach. Let me know if I should request someone else to test this for peanutbase.