### PR TITLE
Tools menu sort and tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The list should adhere to the following schema:
 ```
 
 By default these tools will be listed in a vertical menu on the left side of every page in the site.
-The tools within the list will be grouped by category.
+The tools within the list will be grouped by category. The tool description is shown in a tooltip.
 
 ### `_include/`
 

--- a/_includes/tools-menu.html
+++ b/_includes/tools-menu.html
@@ -4,8 +4,8 @@
 {% for group in groups %}
 <ul class="uk-nav uk-nav-default tm-nav uk-margin-top">
   <li class="uk-nav-header">{{ group.name }}</li>
-  {% for item in group.items %}
-  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {% for item in group.items | sort: "name" %}
+  <li uk-tooltip="title: {{ item.description }}"><a href="{{ item.url }}">{{ item.name }}</a></li>
   {% endfor %}
 </ul>
 {% endfor %}

--- a/_layouts/news-item.html
+++ b/_layouts/news-item.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: reading-width 
 ---
 
 <article class="uk-article">


### PR DESCRIPTION
Moved the `jekyll-legumeinfo` version of  `tools-menu.html` to the theme here, making it sort on tool name and display tooltips.

Also switched the `news-item` layout to use the `reading-width` layout.

Pretty minor stuff.