### PR TITLE
Fix liquid syntax error

### DIFF
--- a/_includes/tools-menu.html
+++ b/_includes/tools-menu.html
@@ -4,7 +4,7 @@
 {% for group in groups %}
 <ul class="uk-nav uk-nav-default tm-nav uk-margin-top">
   <li class="uk-nav-header">{{ group.name }}</li>
-  {% for item in group.items | sort: "name" %}
+  {% for item in group.items %}
   <li uk-tooltip="title: {{ item.description }}"><a href="{{ item.url }}">{{ item.name }}</a></li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
Setting the liquid `error_mode: strict` in a Jekyll _config.yml reveals a syntax error at this line (`Expected end_of_string but found pipe in "item in group.items | sort: "name""`). Proposing to fix the syntax error by removing the attempted `sort`, and leaving the tool ordering as specified in tools.yml