### PR TITLE
Bug fix in get-traits.js

### DIFF
--- a/assets/js/graphql/get-traits.js
+++ b/assets/js/graphql/get-traits.js
@@ -64,7 +64,8 @@ query TraitQuery($pageSize: Int, $page: Int, $name: String, $studyType: String, 
  * @returns {Promise} A `Promise` that resolves to the result of the GraphQL query.
  */
 export function getTraits(queryData={}, pageData={}, options={}) {
-  const {genus, species, type, traits, pubId, author} = queryData;
+  const {genus, species, traits, pubId, author} = queryData;
+  let {type} = queryData;
   if (type === 'QTL') {
     type = 'QTLStudy';
   }


### PR DESCRIPTION
The study type variable was a const, which caused a TypeError with QTL searches as the code tried to reassign the variable to "QTLStudy". 

`type` is now assigned separately from the other variables. 