### PR TITLE
GitHub Action workflow to test jekyll build using starter site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout jekyll-starter-legumeinfo
+        uses: actions/checkout@v4
+        with:
+          repository: legumeinfo/jekyll-starter-legumeinfo
+  
+      - name: Checkout jekyll-theme-legumeinfo
+        uses: actions/checkout@v4
+        with:
+          path: _themes/jekyll-theme-legumeinfo
+          submodules: true
+
+      - name: Build
+        run: docker compose run build


### PR DESCRIPTION
This PR proposes testing commits / PRs made to this theme with a GitHub Actions workflow using the latest version of the starter site (and its Dockerfile / Compose file) as the "driver". While not a comprehensive check, it's easy to implement. Note the GA workflow can be manually triggered via "workflow_dispatch" event, e.g., in case the starter repo & its theme submodule (or a development branch in this theme repo) aren't in sync.