### PR TITLE
gemspec updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ theme: jekyll-theme-legumeinfo
 future: true
 ```
 
+If you are using a version of Jekyll prior to 4.0, you'll need to copy the contents of the theme's [_config.yml](https://github.com/legumeinfo/jekyll-theme-legumeinfo/blob/main/_config.yml) file into your Jekyll site's `_config.yml` file.
+
 Now the theme can be installed via Bundler:
 
     $ bundle

--- a/jekyll-theme-legumeinfo.gemspec
+++ b/jekyll-theme-legumeinfo.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README|_config\.yml)!i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 4.2"
+  spec.add_runtime_dependency "jekyll", ">= 3.5", "< 5.0"
   spec.add_runtime_dependency "webrick", "~> 1.7"
   spec.add_runtime_dependency "jekyll-datapage-generator", "~> 1.4.0"
 end

--- a/jekyll-theme-legumeinfo.gemspec
+++ b/jekyll-theme-legumeinfo.gemspec
@@ -13,6 +13,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README|_config\.yml)!i) }
 
   spec.add_runtime_dependency "jekyll", ">= 3.5", "< 5.0"
-  spec.add_runtime_dependency "webrick", "~> 1.7"
   spec.add_runtime_dependency "jekyll-datapage-generator", "~> 1.4.0"
 end

--- a/jekyll-theme-legumeinfo.gemspec
+++ b/jekyll-theme-legumeinfo.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Alan Cleary"]
   spec.email         = ["acleary@ncgr.org"]
 
-  spec.summary       = "The Jekyll theme for the Legume Information System science portal."
-  spec.homepage      = "https://legumeinfo.org"
+  spec.summary       = "A Jekyll theme for the Legume Information System and related biodata websites."
+  spec.homepage      = "https://github.com/legumeinfo/jekyll-theme-legumeinfo"
   spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README|_config\.yml)!i) }


### PR DESCRIPTION
This PR addresses issue #76. Merging without review since the starter site already specifies a specific version of jekyll in its `Gemfile`, making these changes symbolic more than anything.