### PR TITLE
Explicitly setting no layout for query.js

### DIFF
--- a/assets/js/graphql/query.js
+++ b/assets/js/graphql/query.js
@@ -1,5 +1,6 @@
 ---
 # This YAML front matter ensures Jekyll will pass the site variables in.
+layout: none
 ---
 
 /** The URI of the GraphQL server to query. */


### PR DESCRIPTION
Merging without review because the change is a one-line bug fix.