### PR TITLE
Fixed bug in default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,13 +6,13 @@ layout: base
   {% include left-menu.html %}
 {% endif %}
 <!-- NOTE: putting content between the tools and tm-main blocks will break CSS selectors -->
-<div class="tm-main uk-section uk-section-default uk-flex">
-  <div class="uk-container uk-width-1-1">
-    {{ content }}
+<div class="tm-main uk-section uk-section-default">
+  <div class="uk-container uk-flex">
+    <div class="uk-width-1-1">
+      {{ content }}
+    </div>
+    {% if page.blog_card or page.news_card or page.events_card or page.twitter_card %}
+      {% include card-column.html page=page %}
+    {% endif %}
   </div>
-
-  {% if page.blog_card or page.news_card or page.events_card or page.twitter_card %}
-    {% include card-column.html page=page %}
-  {% endif %}
-
 </div>

--- a/assets/css/uikit-theme.scss
+++ b/assets/css/uikit-theme.scss
@@ -269,7 +269,7 @@ html {
 
 .tm-sidebar-right {
     width: $sidebar-right-width !important;
-    padding-right: 40px;
+    padding-left: 40px;
 }
 
 /* Tablet landscape and bigger */
@@ -291,7 +291,7 @@ html {
     .tm-sidebar-left + .tm-main { padding-left: $sidebar-left-width-xl; }
     .tm-sidebar-right {
         width: $sidebar-right-width-xl !important;
-        padding-right: 45px;
+        padding-left: 45px;
     }
 }
 


### PR DESCRIPTION
I noticed on my big monitor that the content on Jekyll sites was taking the entire width of the page rather than being confined to the maximum width of its container. This PR fixes that.