### PR TITLE
Events now use the reading-width layout

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: reading-width
 ---
 
 <article class="uk-article">


### PR DESCRIPTION
Blog post and news items already do this so this is mostly for consistency.