### PR TITLE
All layouts now support content

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -4,6 +4,8 @@ layout: default
 
 <h1>Blog</h1>
 
+{{ content }}
+
 <dl class="uk-description-list uk-description-list-divider">
 {% for post in site.categories.blog %}
 <dt><a href="{{ post.url }}">{{ post.title }}</a></dt>

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -4,6 +4,8 @@ layout: default
 
 <h1>Events</h1>
 
+{{ content }}
+
 <h2>Current and Upcoming Events</h2>
 <dl id="upcoming-events" class="uk-description-list uk-description-list-divider"></dl>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,6 +2,4 @@
 layout: default
 ---
 
-<div>
-  {{ content }}
-</div>
+{{ content }}

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -4,6 +4,8 @@ layout: default
 
 <h1>News</h1>
 
+{{ content }}
+
 <dl class="uk-description-list uk-description-list-divider">
 {% for post in site.categories.news %}
 <dt><a href="{{ post.url }}">{{ post.title }}</a></dt>

--- a/_layouts/taxa.html
+++ b/_layouts/taxa.html
@@ -3,6 +3,8 @@ layout: default
 ---
 <h1>Taxa</h1>
 
+{{ content }}
+
 {% if site.data.taxon_list %}
 {% assign genera = site.data.taxon_list | group_by: "genus"  %}
 

--- a/_layouts/tools.html
+++ b/_layouts/tools.html
@@ -3,6 +3,8 @@ layout: default
 ---
 <h1>Tools</h1>
 
+{{ content }}
+
 {% if site.data.tools %}
 {% assign groups = site.data.tools | group_by: "category" | sort: "name" %}
 {% for group in groups %}


### PR DESCRIPTION
Specifically, layouts that describe a complete page can now display custom content in addition to the predefined page content. This reduces the need to override layouts when only site-specific text explaining the page needs to be added.