### PR TITLE
Post related content

### DIFF
--- a/_includes/article.html
+++ b/_includes/article.html
@@ -1,0 +1,6 @@
+<article class="uk-article">
+  <h1 class="uk-article-title">{{ include.title }}</h1>
+  <p class="uk-article-meta">{{ include.meta }}</p>
+  <p class="uk-text-lead">{{ include.summary }}</p>
+  {{ include.content }}
+</article>

--- a/_includes/blog-card.html
+++ b/_includes/blog-card.html
@@ -7,7 +7,7 @@
         {% assign blogLimit = site.blog_card_item_limit %}
       {% endif %}
       {% for post in site.categories.blog limit:blogLimit %}
-      <li><b>{{ post.date | date_to_string }}:</b> <a href="{{ post.url }}">{{ post.title }}</a></li>
+        {% include card-item.html url=post.url title=post.title %}
       {% endfor %}
     </ul>
     {% else %}

--- a/_includes/blog-card.html
+++ b/_includes/blog-card.html
@@ -1,5 +1,6 @@
 {% capture content %}
   <div class="uk-card-body">
+    {% if site.categories.blog.size > 0 %}
     <ul class="uk-list uk-list-disc">
       {% assign blogLimit = site.card_item_limit %}
       {% if site.blog_card_item_limit %}
@@ -9,6 +10,9 @@
       <li><b>{{ post.date | date_to_string }}:</b> <a href="{{ post.url }}">{{ post.title }}</a></li>
       {% endfor %}
     </ul>
+    {% else %}
+    <p>There are currently no blog posts.</p>
+    {% endif %}
   </div>
 {% endcapture %}
 

--- a/_includes/card-item.html
+++ b/_includes/card-item.html
@@ -1,0 +1,1 @@
+<li><a href="{{ include.url }}"><b>{{ include.title }}</b></a>{% if include.meta %} {{ include.meta }}{% endif %}</li>

--- a/_includes/events-card.html
+++ b/_includes/events-card.html
@@ -31,12 +31,11 @@ Populate the widget using JavaScript so the site doesn't have to be rebuilt when
   if (upcomingEvents.length > 0) {
     const cardListItems = upcomingEvents
       .map((event) => {
-        const titleLink = `<a href="${ event.url }"><b>${ event.title }</b></a>`;
         let dates = event.date;
         if (event.endDate) {
           dates += ` - ${ event.endDate }`;
         }
-        return `<li>${ titleLink } ${ dates }</li>`;
+        return `{% include card-item.html url='${ event.url }' title='${ event.title }' meta='${ dates }' %}`;
       });
     innerHTML = `
       <ul id="card-upcoming-events" class="uk-list uk-list-disc">

--- a/_includes/events-card.html
+++ b/_includes/events-card.html
@@ -1,7 +1,5 @@
 {% capture content %}
-  <div class="uk-card-body">
-    <ul id="card-upcoming-events" class="uk-list uk-list-disc"></ul>
-  </div>
+  <div id="events-card" class="uk-card-body"></div>
 {% endcapture %}
 
 {% capture footer %}
@@ -26,17 +24,25 @@ Populate the widget using JavaScript so the site doesn't have to be rebuilt when
   const cardUpcomingEvents = upcomingEvents.slice(0, eventsLimit);
 
   /* generate HTML for each event */
-  const cardListItems = upcomingEvents
-    .map((event) => {
-      const titleLink = `<a href="${ event.url }"><b>${ event.title }</b></a>`;
-      let dates = event.date;
-      if (event.endDate) {
-        dates += ` - ${ event.endDate }`;
-      }
-      return `<li>${ titleLink } ${ dates }</li>`;
-    });
 
   /* add the upcoming events to the upcoming events element */
-  const cardEventList = document.getElementById("card-upcoming-events");
-  cardEventList.innerHTML = cardListItems.join("");
+  const cardEventList = document.getElementById("events-card");
+  let innerHTML = "<p>There are no current or upcoming events.</p>";
+  if (upcomingEvents.length > 0) {
+    const cardListItems = upcomingEvents
+      .map((event) => {
+        const titleLink = `<a href="${ event.url }"><b>${ event.title }</b></a>`;
+        let dates = event.date;
+        if (event.endDate) {
+          dates += ` - ${ event.endDate }`;
+        }
+        return `<li>${ titleLink } ${ dates }</li>`;
+      });
+    innerHTML = `
+      <ul id="card-upcoming-events" class="uk-list uk-list-disc">
+        ${ cardListItems.join("") }
+      </ul>
+    `;
+  }
+  cardEventList.innerHTML = innerHTML;
 </script>

--- a/_includes/news-card.html
+++ b/_includes/news-card.html
@@ -7,7 +7,8 @@
         {% assign newsLimit = site.news_card_item_limit %}
       {% endif %}
       {% for post in site.categories.news limit:newsLimit %}
-      <li><a href="{{ post.url }}"><b>{{ post.title }}</b></a></li>
+        {% capture meta %}{{ post.date | date_to_long_string }}{% endcapture %}
+        {% include card-item.html url=post.url title=post.title meta=meta%}
       {% endfor %}
     </ul>
     {% else %}

--- a/_includes/news-card.html
+++ b/_includes/news-card.html
@@ -1,5 +1,6 @@
 {% capture content %}
   <div class="uk-card-body">
+    {% if site.categories.news.size > 0 %}
     <ul class="uk-list uk-list-disc">
       {% assign newsLimit = site.card_item_limit %}
       {% if site.news_card_item_limit %}
@@ -9,6 +10,9 @@
       <li><a href="{{ post.url }}"><b>{{ post.title }}</b></a></li>
       {% endfor %}
     </ul>
+    {% else %}
+    <p>There are currently no news items.</p>
+    {% endif %}
   </div>
 {% endcapture %}
 

--- a/_includes/post-description.html
+++ b/_includes/post-description.html
@@ -1,0 +1,2 @@
+<dt><a href="{{ include.url }}"><b>{{ include.title }}</b></a> | {{ include.date }}{% if include.author %} <span class="uk-text-muted">{{ include.author }}</span>{% endif %}</dt>
+<dd>{{ include.summary }}</dd>

--- a/_includes/post-description.html
+++ b/_includes/post-description.html
@@ -1,2 +1,2 @@
-<dt><a href="{{ include.url }}"><b>{{ include.title }}</b></a> | {{ include.date }}{% if include.author %} <span class="uk-text-muted">{{ include.author }}</span>{% endif %}</dt>
+<dt><a href="{{ include.url }}"><b>{{ include.title }}</b></a> | <span class="uk-text-muted">{{ include.meta }}</span></dt>
 <dd>{{ include.summary }}</dd>

--- a/_includes/twitter-card.html
+++ b/_includes/twitter-card.html
@@ -7,7 +7,7 @@
 {% capture content %}
   {% if site.twitter_username %}
   <!-- code from Twitter -->
-  <a class="twitter-timeline uk-padding-small"
+  <p><a class="twitter-timeline uk-padding-small"
     href="https://twitter.com/{{ site.twitter_username }}"
     data-tweet-limit={% if site.twitter_card_item_limit %}
       {{ site.twitter_card_item_limit }}
@@ -16,19 +16,21 @@
     {% endif %}
     data-chrome="noheader, nofooter, noborders"
     dnt=true
-  >Tweets by {{ site.twitter_username }}</a>
+  ><b>Tweets by {{ site.twitter_username }}</b></a></p>
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   <!-- end code from Twitter -->
   {% else %}
-  <span class="uk-padding-small uk-text-danger">No Twitter username provided</span>
+  <div class="uk-card-body">
+    <p class="uk-text-danger">No Twitter username provided</p>
+  </div>
   {% endif %}
 {% endcapture %}
 
 {% capture footer %}
-    <a class="uk-button uk-button-text"
-      href="https://twitter.com/{{ site.twitter_username }}"
-      target="_blank"
-    >More Tweets</a>
+  <a class="uk-button uk-button-text"
+    href="https://twitter.com/{{ site.twitter_username }}"
+    target="_blank"
+  >More Tweets</a>
 {% endcapture %}
 
 {% include card.html title=title content=content footer=footer %}

--- a/_layouts/blog-post.html
+++ b/_layouts/blog-post.html
@@ -1,8 +1,6 @@
 ---
 layout: reading-width
 ---
-<article class="uk-article">
-  <h1 class="uk-article-title">{{ page.title }}</h1>
-  <p class="uk-article-meta">Posted by {{ page.author }} on {{ page.date | date_to_long_string }}.</p>
-  {{ content }}
-</article>
+
+{% capture meta %}Posted by {{ page.author }} on {{ page.date | date_to_long_string }}{% endcapture %}
+{% include article.html title=page.title meta=meta summary=page.summary content=content %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -10,8 +10,8 @@ layout: default
 {% if site.categories.blog.size > 0 %}
 <dl class="uk-description-list uk-description-list-divider">
 {% for post in site.categories.blog %}
-  {% capture date %}{{ post.date | date_to_long_string }}{% endcapture %}
-  {% include post-description.html url=post.url title=post.title date=date author=post.author summary=post.summary %}
+  {% capture meta %}{{ post.author }}, {{ post.date | date_to_long_string }}{% endcapture %}
+  {% include post-description.html url=post.url title=post.title date=date meta=meta summary=post.summary %}
 {% endfor %}
 </dl>
 {% else %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -6,9 +6,14 @@ layout: default
 
 {{ content }}
 
+<h2 class="uk-heading-divider">Posts</h2>
+{% if site.categories.blog.size > 0 %}
 <dl class="uk-description-list uk-description-list-divider">
 {% for post in site.categories.blog %}
 <dt><a href="{{ post.url }}">{{ post.title }}</a></dt>
   <dd>{{ post.summary }}</dd>
 {% endfor %}
 </dl>
+{% else %}
+<p>There are currently no blog posts.</p>
+{% endif %}

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -10,8 +10,8 @@ layout: default
 {% if site.categories.blog.size > 0 %}
 <dl class="uk-description-list uk-description-list-divider">
 {% for post in site.categories.blog %}
-<dt><a href="{{ post.url }}">{{ post.title }}</a></dt>
-  <dd>{{ post.summary }}</dd>
+  {% capture date %}{{ post.date | date_to_long_string }}{% endcapture %}
+  {% include post-description.html url=post.url title=post.title date=date author=post.author summary=post.summary %}
 {% endfor %}
 </dl>
 {% else %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -2,13 +2,5 @@
 layout: reading-width
 ---
 
-<article class="uk-article">
-  <h1 class="uk-article-title">{{ page.title }}</h1>
-
-  <p class="uk-article-meta">{{ page.date | date_to_string }}{% if page.end_date %} - {{ page.end_date | date_to_string }}{% endif %}</p>
-
-  <p class="uk-text-lead">{{ page.summary }}</p>
-
-  {{ content }}
-
-</article>
+{% capture meta %}When: {{ page.date | date_to_long_string }}{% if page.end_date %} - {{ page.end_date | date_to_long_string }}{% endif %}{% endcapture %}
+{% include article.html title=page.title meta=meta summary=page.summary content=content %}

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -6,11 +6,13 @@ layout: default
 
 {{ content }}
 
-<h2>Current and Upcoming Events</h2>
-<dl id="upcoming-events" class="uk-description-list uk-description-list-divider"></dl>
+<h2 class="uk-heading-divider">Current and Upcoming Events</h2>
 
-<h2>Past Events</h2>
-<dl id="past-events" class="uk-description-list uk-description-list-divider"></dl>
+<div id="upcoming-events"></div>
+
+<h2 class="uk-heading-divider">Past Events</h2>
+
+<div id="past-events"></div>
 
 {% comment %}
 Populate the description lists using JavaScript so the site doesn't have to be rebuilt when the event is over
@@ -32,14 +34,30 @@ Populate the description lists using JavaScript so the site doesn't have to be r
     `;
   }
 
-  /* generate HTML for events */
-  const upcomingHtml = upcomingEvents.map(eventHtml);
-  const pastHtml = pastEvents.map(eventHtml);
-
-  /* add the events to the events elements */
+  /* add the current and upcoming events */
+  let innerHTML = "<p>There are no current or upcoming events.</p>";
+  if (upcomingEvents.length > 0) {
+    const upcomingHtml = upcomingEvents.map(eventHtml);
+    innerHTML = `
+      <dl class="uk-description-list uk-description-list-divider">
+        ${ upcomingHtml.join("") }
+      </dl>
+    `;
+  }
   const upcomingElement = document.getElementById("upcoming-events");
-  upcomingElement.innerHTML = upcomingHtml.join("");
+  upcomingElement.innerHTML = innerHTML;
+
+  /* add the current and upcoming events */
+  innerHTML = "<p>There are no past events.</p>";
+  if (pastEvents.length > 0) {
+    const pastHtml = pastEvents.map(eventHtml);
+    innerHTML = `
+      <dl class="uk-description-list uk-description-list-divider">
+        ${ pastHtml.join("") }
+      </dl>
+    `;
+  }
   const pastElement = document.getElementById("past-events");
-  pastElement.innerHTML = pastHtml.join("");
+  pastElement.innerHTML = innerHTML;
 
 </script>

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -23,13 +23,12 @@ Populate the description lists using JavaScript so the site doesn't have to be r
 
   /* generates the description list HTML for an event */
   function eventHtml(event) {
-    const titleLink = `<a href="${ event.url }"><b>${ event.title }</b></a>`;
     let dates = event.date;
     if (event.endDate) {
       dates += ` - ${ event.endDate }`;
     }
     return `
-      {% include post-description.html url='${ event.url }' title='${ event.title }' date='${ dates }' summary='${ event.summary }' %}
+      {% include post-description.html url='${ event.url }' title='${ event.title }' meta='${ dates }' summary='${ event.summary }' %}
     `;
   }
 

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -29,8 +29,7 @@ Populate the description lists using JavaScript so the site doesn't have to be r
       dates += ` - ${ event.endDate }`;
     }
     return `
-      <dt>${ titleLink } ${ dates }</dt>
-      <dd>${ event.summary }<dd>
+      {% include post-description.html url='${ event.url }' title='${ event.title }' date='${ dates }' summary='${ event.summary }' %}
     `;
   }
 

--- a/_layouts/news-item.html
+++ b/_layouts/news-item.html
@@ -1,14 +1,6 @@
 ---
-layout: reading-width 
+layout: reading-width
 ---
 
-<article class="uk-article">
-  <h1 class="uk-article-title">{{ page.title }}</h1>
-
-  <p class="uk-article-meta">Written by {{ page.author }} on {{ page.date | date_to_string }}.</p>
-
-  <p class="uk-text-lead">{{ page.summary }}</p>
-
-  {{ content }}
-
-</article>
+{% capture meta %}Posted on {{ page.date | date_to_long_string }}{% endcapture %}
+{% include article.html title=page.title meta=meta summary=page.summary content=content %}

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -10,8 +10,8 @@ layout: default
 {% if site.categories.news.size > 0 %}
 <dl class="uk-description-list uk-description-list-divider">
 {% for post in site.categories.news %}
-  {% capture date %}{{ post.date | date_to_long_string }}{% endcapture %}
-  {% include post-description.html url=post.url title=post.title date=date summary=post.summary %}
+  {% capture meta %}{{ post.date | date_to_long_string }}{% endcapture %}
+  {% include post-description.html url=post.url title=post.title meta=meta summary=post.summary %}
 {% endfor %}
 </dl>
 {% else %}

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -6,9 +6,14 @@ layout: default
 
 {{ content }}
 
+<h2 class="uk-heading-divider">Items</h2>
+{% if site.categories.news.size > 0 %}
 <dl class="uk-description-list uk-description-list-divider">
 {% for post in site.categories.news %}
 <dt><a href="{{ post.url }}">{{ post.title }}</a></dt>
   <dd>{{ post.summary }}</dd>
 {% endfor %}
 </dl>
+{% else %}
+<p>There are currently no news items.</p>
+{% endif %}

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -10,8 +10,8 @@ layout: default
 {% if site.categories.news.size > 0 %}
 <dl class="uk-description-list uk-description-list-divider">
 {% for post in site.categories.news %}
-<dt><a href="{{ post.url }}">{{ post.title }}</a></dt>
-  <dd>{{ post.summary }}</dd>
+  {% capture date %}{{ post.date | date_to_long_string }}{% endcapture %}
+  {% include post-description.html url=post.url title=post.title date=date summary=post.summary %}
 {% endfor %}
 </dl>
 {% else %}

--- a/assets/css/uikit-theme.scss
+++ b/assets/css/uikit-theme.scss
@@ -248,6 +248,9 @@ html {
     overflow-x: hidden;
 }
 
+/* override description list text transform */
+dl > dt { text-transform: none !important; }
+
 
 /* Documentation Sidebars
  ========================================================================== */


### PR DESCRIPTION
The blog, news, and events are all "post" content, yet they were all being presented in a stylistically inconsistent way. This PR uses Jekyll layouts and includes to clean that up. Reviewers should specifically look at the post card widgets on the homepage, the post landing pages, and the specific post pages for blog, news, and events content.