### PR TITLE
Linkouts for trait associations

### DIFF
--- a/assets/js/graphql/get-genes.js
+++ b/assets/js/graphql/get-genes.js
@@ -232,3 +232,9 @@ export function geneAllModalLinksFactory(modalId) {
     panGeneSetsModalLinkFactory(modalId),
   ];
 }
+
+/**
+ * Deprecated alias for geneAllModalLinksFactory, for backward compatibility until
+ * we have enough significant breaking changes to warrant a major revision update
+ */
+export const allModalLinksFactory = geneAllModalLinksFactory;

--- a/assets/js/graphql/get-genes.js
+++ b/assets/js/graphql/get-genes.js
@@ -224,7 +224,7 @@ export function panGeneSetsModalLinkFactory(modalId) {
  * @param {string} modalId - The HTML `id` of the target modal element.
  * @returns {Function[]} The created callback functions.
  */
-export function allModalLinksFactory(modalId) {
+export function geneAllModalLinksFactory(modalId) {
   return [
     geneIdentifierModalLinkFactory(modalId),
     locationModalLinkFactory(modalId),

--- a/assets/js/graphql/get-linkouts.js
+++ b/assets/js/graphql/get-linkouts.js
@@ -219,8 +219,8 @@ export function panGeneSetLinkoutsFunction(linkoutData, options) {
 
 /** The GraphQL query used to get linkouts for GWAS. */
 export const getGWASLinkoutsQuery = `
-  query GWASLinkoutsQuery($identifier: ID!) {
-    GWASLinkouts(identifier: $identifier) {
+  query gwasLinkoutsQuery($identifier: ID!) {
+    gwasLinkouts(identifier: $identifier) {
       results {
         href
         text
@@ -252,7 +252,7 @@ export function getGWASLinkouts(queryData={}, options={}) {
  * @returns {object} A `LinkoutResults` object.
  */
 export function GWASLinkoutsToLinkoutResults(data) {
-  const results = data.GWASLinkouts.results;
+  const results = data.gwasLinkouts.results;
   return {results};
 }
 
@@ -266,15 +266,15 @@ export function GWASLinkoutsToLinkoutResults(data) {
  * `LisLinkoutElement` (`<lis-linkout-element>`) Web Component.
  */
 export function GWASLinkoutsFunction(linkoutData, options) {
-  return getGWASStudyLinkouts(linkoutData, options)
+  return getGWASLinkouts(linkoutData, options)
     .then(({data}) => GWASLinkoutsToLinkoutResults(data));
 }
 
 
 /** The GraphQL query used to get linkouts for QTLStudies. */
 export const getQTLStudyLinkoutsQuery = `
-  query QTLStudyLinkoutsQuery($identifier: ID!) {
-    QTLStudyLinkouts(identifier: $identifier) {
+  query qtlStudyLinkoutsQuery($identifier: ID!) {
+    qtlStudyLinkouts(identifier: $identifier) {
       results {
         href
         text
@@ -291,7 +291,7 @@ export const getQTLStudyLinkoutsQuery = `
  * namely, an optional `AbortSignal` instance that can be used to cancel the request mid-flight.
  * @returns {Promise} A `Promise` that resolves to the result of the GraphQL query.
  */
-export function getQTLStudiesLinkouts(queryData={}, options={}) {
+export function getQTLStudyLinkouts(queryData={}, options={}) {
   const {identifier} = queryData;
   const variables = {identifier};
   const {abortSignal} = options;
@@ -306,7 +306,7 @@ export function getQTLStudiesLinkouts(queryData={}, options={}) {
  * @returns {object} A `LinkoutResults` object.
  */
 export function QTLStudyLinkoutsToLinkoutResults(data) {
-  const results = data.QTLStudyLinkouts.results;
+  const results = data.qtlStudyLinkouts.results;
   return {results};
 }
 
@@ -343,9 +343,9 @@ export function allLinkoutsFunction({type, linkoutData}, options) {
       return geneFamilyLinkoutsFunction(linkoutData, options);
     case 'panGeneSet':
       return panGeneSetLinkoutsFunction(linkoutData, options);
-    case 'gwas':
+    case 'GWAS':
       return GWASLinkoutsFunction(linkoutData, options);
-    case 'qtlStudy':
+    case 'QTLStudy':
       return QTLStudyLinkoutsFunction(linkoutData, options);
   }
   return Promise.reject();

--- a/assets/js/graphql/get-linkouts.js
+++ b/assets/js/graphql/get-linkouts.js
@@ -217,6 +217,114 @@ export function panGeneSetLinkoutsFunction(linkoutData, options) {
 }
 
 
+/** The GraphQL query used to get linkouts for GWAS. */
+export const getGWASLinkoutsQuery = `
+  query GWASLinkoutsQuery($identifier: ID!) {
+    GWASLinkouts(identifier: $identifier) {
+      results {
+        href
+        text
+      }
+    }
+  }
+`;
+
+
+/**
+ * Gets linkouts for GWAS from GraphQL.
+ * @param {object} queryData - An object containing zero or more variables for the GraphQL query.
+ * @param {object} options - An object containing optional parameters for the HTTP request,
+ * namely, an optional `AbortSignal` instance that can be used to cancel the request mid-flight.
+ * @returns {Promise} A `Promise` that resolves to the result of the GraphQL query.
+ */
+export function getGWASLinkouts(queryData={}, options={}) {
+  const {identifier} = queryData;
+  const variables = {identifier};
+  const {abortSignal} = options;
+  return query(getGWASLinkoutsQuery, variables, abortSignal);
+}
+
+
+/**
+ * Converts GraphQL `GWASLinkoutsResults` into the `LinkoutResults` used by the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component.
+ * @param {object} data - An object containing the data portional of the GraphQL query HTTP response.
+ * @returns {object} A `LinkoutResults` object.
+ */
+export function GWASLinkoutsToLinkoutResults(data) {
+  const results = data.GWASLinkouts.results;
+  return {results};
+}
+
+
+/**
+ * The GWAS linkouts function to use for the `linkoutFunction` property of the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component.
+ * @param {object} linkoutData - An object containing the data needed to get linkouts.
+ * @param {object} options - An object containing optional parameters to pass to the `getGeneLinkouts` function.
+ * @returns {Promise} A `Promise` that resolves to the `LinkoutResults` used by the
+ * `LisLinkoutElement` (`<lis-linkout-element>`) Web Component.
+ */
+export function GWASLinkoutsFunction(linkoutData, options) {
+  return getGWASStudyLinkouts(linkoutData, options)
+    .then(({data}) => GWASLinkoutsToLinkoutResults(data));
+}
+
+
+/** The GraphQL query used to get linkouts for QTLStudies. */
+export const getQTLStudyLinkoutsQuery = `
+  query QTLStudyLinkoutsQuery($identifier: ID!) {
+    QTLStudyLinkouts(identifier: $identifier) {
+      results {
+        href
+        text
+      }
+    }
+  }
+`;
+
+
+/**
+ * Gets linkouts for QTLStudies from GraphQL.
+ * @param {object} queryData - An object containing zero or more variables for the GraphQL query.
+ * @param {object} options - An object containing optional parameters for the HTTP request,
+ * namely, an optional `AbortSignal` instance that can be used to cancel the request mid-flight.
+ * @returns {Promise} A `Promise` that resolves to the result of the GraphQL query.
+ */
+export function getQTLStudiesLinkouts(queryData={}, options={}) {
+  const {identifier} = queryData;
+  const variables = {identifier};
+  const {abortSignal} = options;
+  return query(getQTLStudyLinkoutsQuery, variables, abortSignal);
+}
+
+
+/**
+ * Converts GraphQL `QTLStudyLinkoutsResults` into the `LinkoutResults` used by the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component.
+ * @param {object} data - An object containing the data portional of the GraphQL query HTTP response.
+ * @returns {object} A `LinkoutResults` object.
+ */
+export function QTLStudyLinkoutsToLinkoutResults(data) {
+  const results = data.QTLStudyLinkouts.results;
+  return {results};
+}
+
+
+/**
+ * The QTLStudy linkouts function to use for the `linkoutFunction` property of the `LisLinkoutElement`
+ * (`<lis-linkout-element>`) Web Component.
+ * @param {object} linkoutData - An object containing the data needed to get linkouts.
+ * @param {object} options - An object containing optional parameters to pass to the `getGeneLinkouts` function.
+ * @returns {Promise} A `Promise` that resolves to the `LinkoutResults` used by the
+ * `LisLinkoutElement` (`<lis-linkout-element>`) Web Component.
+ */
+export function QTLStudyLinkoutsFunction(linkoutData, options) {
+  return getQTLStudyLinkouts(linkoutData, options)
+    .then(({data}) => QTLStudyLinkoutsToLinkoutResults(data));
+}
+
+
 /**
  * A linkouts function to use for the `linkoutFunction` property of the `LisLinkoutElement`
  * (`<lis-linkout-element>`) Web Component that supports all linkout types.
@@ -235,6 +343,10 @@ export function allLinkoutsFunction({type, linkoutData}, options) {
       return geneFamilyLinkoutsFunction(linkoutData, options);
     case 'panGeneSet':
       return panGeneSetLinkoutsFunction(linkoutData, options);
+    case 'gwas':
+      return GWASLinkoutsFunction(linkoutData, options);
+    case 'qtlStudy':
+      return QTLStudyLinkoutsFunction(linkoutData, options);
   }
   return Promise.reject();
 }

--- a/assets/js/graphql/get-traits.js
+++ b/assets/js/graphql/get-traits.js
@@ -153,11 +153,14 @@ export function traitSearchFunctionFactory(...callbacks) {
 export function GWASModalLinkFactory(modalId) {
   return ({results: oldResults, ...pageInfo}) => {
     const results = oldResults.map(({identifier, type, ...traitInfo}) => {
-      const data = {identifier, type: 'GWAS'};
+      if (type === "GWAS") {
+        const data = {identifier, type: 'GWAS'};
+        identifier = modalLink(modalId, identifier, data);
+      }
       return {
         ...traitInfo,
-        identifier: (type == "GWAS" ? modalLink(modalId, identifier, data) : identifier),
-        type: type
+        identifier: identifier,
+        type: type,
       }
     });
     return {...pageInfo, results};
@@ -174,11 +177,14 @@ export function GWASModalLinkFactory(modalId) {
 export function QTLStudiesModalLinkFactory(modalId) {
   return ({results: oldResults, ...pageInfo}) => {
     const results = oldResults.map(({identifier, type, ...traitInfo}) => {
-      const data = {identifier, type: 'QTLStudy'};
+      if (type === "QTL") {
+        const data = {identifier, type: 'QTLStudy'};
+        identifier = modalLink(modalId, identifier, data);
+      }
       return {
         ...traitInfo,
-        identifier: (type === "QTL" ? modalLink(modalId, identifier, data) : identifier),
-        type: type
+        identifier: identifier,
+        type: type,
       }
     });
     return {...pageInfo, results};
@@ -191,7 +197,7 @@ export function QTLStudiesModalLinkFactory(modalId) {
  * @param {string} modalId - The HTML `id` of the target modal element.
  * @returns {Function[]} The created callback functions.
  */
-export function allTraitModalLinksFactory(modalId) {
+export function traitAllModalLinksFactory(modalId) {
   return [
     GWASModalLinkFactory(modalId),
     QTLStudiesModalLinkFactory(modalId),

--- a/assets/js/graphql/get-traits.js
+++ b/assets/js/graphql/get-traits.js
@@ -1,4 +1,5 @@
 import { query } from './query.js';
+import { modalLink } from './modal.js';
 
 
 /** The GraphQL query used to get traits. */
@@ -140,4 +141,59 @@ export function traitSearchFunctionFactory(...callbacks) {
         });
         return promise;
     };
+}
+
+/**
+ * Creates a callback function that can be used with the `traitSearchFunctionFactory` function
+ * to convert `GWAS` in the `PaginatedSearchResults<TraitSearchResult[]>` into links that
+ * open a modal with the given `modalId`.
+ * @param {string} modalId - The HTML `id` of the target modal element.
+ * @returns {Function} The created callback function.
+ */
+export function GWASModalLinkFactory(modalId) {
+  return ({results: oldResults, ...pageInfo}) => {
+    const results = oldResults.map(({identifier, type, ...traitInfo}) => {
+      const data = {identifier, type: 'GWAS'};
+      return {
+        ...traitInfo,
+        identifier: (type == "GWAS" ? modalLink(modalId, identifier, data) : identifier),
+        type: type
+      }
+    });
+    return {...pageInfo, results};
+  }
+}
+
+/**
+ * Creates a callback function that can be used with the `traitSearchFunctionFactory` function
+ * to convert `QTLStudies` in the `PaginatedSearchResults<TraitSearchResult[]>` into links that
+ * open a modal with the given `modalId`.
+ * @param {string} modalId - The HTML `id` of the target modal element.
+ * @returns {Function} The created callback function.
+ */
+export function QTLStudiesModalLinkFactory(modalId) {
+  return ({results: oldResults, ...pageInfo}) => {
+    const results = oldResults.map(({identifier, type, ...traitInfo}) => {
+      const data = {identifier, type: 'QTLStudy'};
+      return {
+        ...traitInfo,
+        identifier: (type === "QTL" ? modalLink(modalId, identifier, data) : identifier),
+        type: type
+      }
+    });
+    return {...pageInfo, results};
+  }
+}
+
+/**
+ * Creates all callback functions that can be used with the `traitSearchFunctionFactory` function
+ * to add modal links to the `PaginatedSearchResults<TraitSearchResult[]>`.
+ * @param {string} modalId - The HTML `id` of the target modal element.
+ * @returns {Function[]} The created callback functions.
+ */
+export function allTraitModalLinksFactory(modalId) {
+  return [
+    GWASModalLinkFactory(modalId),
+    QTLStudiesModalLinkFactory(modalId),
+  ];
 }

--- a/assets/js/graphql/get-traits.js
+++ b/assets/js/graphql/get-traits.js
@@ -150,17 +150,18 @@ export function traitSearchFunctionFactory(...callbacks) {
  * @param {string} modalId - The HTML `id` of the target modal element.
  * @returns {Function} The created callback function.
  */
-export function GWASModalLinkFactory(modalId) {
+export function gwasIdentifierModalLinkFactory(modalId) {
   return ({results: oldResults, ...pageInfo}) => {
-    const results = oldResults.map(({identifier, type, ...traitInfo}) => {
+    const results = oldResults.map(({identifier: oldIdentifier, type, ...traitInfo}) => {
+      let identifier = oldIdentifier;
       if (type === "GWAS") {
         const data = {identifier, type: 'GWAS'};
         identifier = modalLink(modalId, identifier, data);
       }
       return {
         ...traitInfo,
-        identifier: identifier,
-        type: type,
+        identifier,
+        type,
       }
     });
     return {...pageInfo, results};
@@ -174,17 +175,18 @@ export function GWASModalLinkFactory(modalId) {
  * @param {string} modalId - The HTML `id` of the target modal element.
  * @returns {Function} The created callback function.
  */
-export function QTLStudiesModalLinkFactory(modalId) {
+export function qtlStudyIdentifierModalLinkFactory(modalId) {
   return ({results: oldResults, ...pageInfo}) => {
-    const results = oldResults.map(({identifier, type, ...traitInfo}) => {
+    const results = oldResults.map(({identifier: oldIdentifier, type, ...traitInfo}) => {
+      let identifier = oldIdentifier;
       if (type === "QTL") {
         const data = {identifier, type: 'QTLStudy'};
         identifier = modalLink(modalId, identifier, data);
       }
       return {
         ...traitInfo,
-        identifier: identifier,
-        type: type,
+        identifier,
+        type,
       }
     });
     return {...pageInfo, results};
@@ -199,7 +201,7 @@ export function QTLStudiesModalLinkFactory(modalId) {
  */
 export function traitAllModalLinksFactory(modalId) {
   return [
-    GWASModalLinkFactory(modalId),
-    QTLStudiesModalLinkFactory(modalId),
+    gwasIdentifierModalLinkFactory(modalId),
+    qtlStudyIdentifierModalLinkFactory(modalId),
   ];
 }


### PR DESCRIPTION
adding support for calling linkouts on GWAS and QTLStudies. Slightly different than previous models in that the logic that adds the links needs to be aware of whether the given identifier comes from a GWAS or a QTLStudy.